### PR TITLE
Adds IsFallDamage() to DeathPopup Check

### DIFF
--- a/lilia/modules/core/spawns/libraries/server.lua
+++ b/lilia/modules/core/spawns/libraries/server.lua
@@ -71,7 +71,7 @@ end
 function SpawnsCore:PlayerDeath(client, _, attacker)
     local char = client:getChar()
     if not char then return end
-    if self.DeathPopupEnabled and not attacker:IsWorld() then
+    if self.DeathPopupEnabled and not attacker:IsWorld() and not IsFallDamage() then
         net.Start("death_client")
         net.WriteString(attacker:Nick())
         net.WriteFloat(attacker:getChar():getID())


### PR DESCRIPTION
Adds ```IsFallDamage()``` to the check 
```if self.DeathPopupEnabled and not attacker:IsWorld() then```

to Fix the following error when being killed by fall damage 
```
 [Srlion's Hook Library] gamemodes/lilia/modules/core/spawns/libraries/server.lua:76: attempt to call method 'Nick' (a nil value)
  1. func - gamemodes/lilia/modules/core/spawns/libraries/server.lua:76
   2. unknown - lua/includes/modules/hook.lua:247
   ```
   Probably a shity way to fix not sure 