### PR TITLE
Update server.lua

### DIFF
--- a/lilia/modules/core/protection/submodules/antifamilysharing/libraries/server.lua
+++ b/lilia/modules/core/protection/submodules/antifamilysharing/libraries/server.lua
@@ -1,7 +1,5 @@
-function AntiFamilySharing:PlayerAuthed(client, steamid)
-
+﻿function AntiFamilySharing:PlayerAuthed(client, steamid)
     local steamworks = steamworks or _G.steamworks
-
     if not steamworks then
         print("Error: 'steamworks' is not available.")
         return
@@ -44,9 +42,7 @@ function AntiFamilySharing:PlayerAuthed(client, steamid)
 
     local function notifyCallback(printMessage)
         for _, admin in ipairs(player.GetAll()) do
-            if IsValid(admin) and CAMI.PlayerHasAccess(admin, "Staff Permissions - Can See Family Sharing Notifications", nil) then
-                admin:ChatPrint(printMessage)
-            end
+            if IsValid(admin) and CAMI.PlayerHasAccess(admin, "Staff Permissions - Can See Family Sharing Notifications", nil) then admin:ChatPrint(printMessage) end
         end
     end
 

--- a/lilia/modules/core/protection/submodules/antifamilysharing/libraries/server.lua
+++ b/lilia/modules/core/protection/submodules/antifamilysharing/libraries/server.lua
@@ -1,12 +1,20 @@
-﻿function AntiFamilySharing:PlayerAuthed(client, steamid)
-    local OwnerAccount = "Unknown"
+function AntiFamilySharing:PlayerAuthed(client, steamid)
+
+    local steamworks = steamworks or _G.steamworks
+
+    if not steamworks then
+        print("Error: 'steamworks' is not available.")
+        return
+    end
+
     local steamID64 = util.SteamIDTo64(steamid)
     local OwnerSteamID64 = client:OwnerSteamID64()
     local JoiningPlayerName = client:steamName()
     local JoiningPlayerSteamID = client:SteamID()
-    local function notifyAdmin(isBanned, isSharingEnabled, isBlacklisted)
+    local OwnerAccount = "Unknown"
+    local function notifyAdmin(isBanned, isSharingEnabled, isBlacklisted, callback)
         for _, admin in ipairs(player.GetAll()) do
-            if IsValid(admin) and CAMI and CAMI.PlayerHasAccess(admin, "Staff Permissions - Can See Family Sharing Notifications", nil) then
+            if IsValid(admin) and CAMI.PlayerHasAccess(admin, "Staff Permissions - Can See Family Sharing Notifications", nil) then
                 steamworks.RequestPlayerInfo(
                     OwnerSteamID64,
                     function(name)
@@ -26,10 +34,18 @@
                             end
                         end
 
-                        admin:ChatPrint(printMessage)
+                        callback(printMessage)
                     end,
                     function(error) print("Steamworks request error:", error) end
                 )
+            end
+        end
+    end
+
+    local function notifyCallback(printMessage)
+        for _, admin in ipairs(player.GetAll()) do
+            if IsValid(admin) and CAMI.PlayerHasAccess(admin, "Staff Permissions - Can See Family Sharing Notifications", nil) then
+                admin:ChatPrint(printMessage)
             end
         end
     end
@@ -38,20 +54,20 @@
     if self.FamilySharingEnabled then
         if WhitelistCore and table.HasValue(WhitelistCore.BlacklistedSteamID64, OwnerSteamID64) then
             client:Ban("You are using an account whose family share is blacklisted from this server!")
-            notifyAdmin(true, true, true)
+            notifyAdmin(true, true, true, notifyCallback)
         elseif OwnerSteamID64 ~= steamID64 then
             if isBanned then
                 client:Ban(banReason)
-                notifyAdmin(isBanned, true, false)
+                notifyAdmin(isBanned, true, true, notifyCallback)
             end
         end
     else
         if isBanned then
             client:Ban(banReason)
-            notifyAdmin(isBanned, false, false)
+            notifyAdmin(isBanned, true, true, notifyCallback)
         else
             client:Kick("Sorry! We do not allow family shared accounts in this server! Reason: Family Sharing")
-            notifyAdmin(false, false, false)
+            notifyAdmin(false, false, false, notifyCallback)
             print(client:steamName() .. " (" .. client:SteamID() .. ") kicked for family sharing.")
         end
     end


### PR DESCRIPTION
Fix's family share issue with steamworks returning a nil value, also added a callback instead of just the admin:Chatprint due to the nature of steamworks.RequestPlayerInfo. Still needs to be fully tested 